### PR TITLE
Almonds Stable Core — initial implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "snack-stash"
-version = "0.1.0"
+version = "0.0.1"
 description = "A CLI tool for managing a personal stash of reusable Python code snippets."
 requires-python = ">=3.10"
 dependencies = [

--- a/snacks/main.py
+++ b/snacks/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import os
 import shutil
 from pathlib import Path
@@ -16,6 +17,22 @@ app = typer.Typer(
     help="Manage your personal snack stash of reusable Python snippets.",
     no_args_is_help=True,
 )
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        version = importlib.metadata.version("snack-stash")
+        typer.echo(f"snack-stash v{version}")
+        raise typer.Exit()
+
+
+@app.callback()
+def _main(
+    version: Optional[bool] = typer.Option(
+        None, "--version", callback=_version_callback, is_eager=True, help="Show version and exit."
+    ),
+) -> None:
+    pass
 
 stash_app = typer.Typer(help="Manage stash directories.")
 app.add_typer(stash_app, name="stash")


### PR DESCRIPTION
## Summary

Implements the complete Almonds Stable Core: all snippet commands, stash management, remote stash support, configuration system, packaging, CI/CD, tests, and documentation.

Closes #1, Closes #2, Closes #3, Closes #4, Closes #5, Closes #6, Closes #7, Closes #8

## Changes

- **Snippet commands** — `snack list [category]`, `snack search`, `snack unpack [--flat] [--force]`, `snack pack [--force]` with overwrite prompts and clear error messages
- **Stash management** — `snack stash create`, `snack stash list`, `snack stash move`; named stashes written to `~/.snackstashrc` in INI format; legacy `stash=<path>` format still read
- **Remote stash** — `snack stash add-remote owner/repo [--subdir] [--force]`; downloads GitHub tarball via stdlib `urllib`/`tarfile`, copies `.py` files preserving directory structure
- **Configuration** — `SnackConfig` class with priority order: `SNACK_STASH` env var → active named stash → error; every misconfiguration produces an actionable message
- **Version flag** — `snack --version` reads from package metadata; `pyproject.toml` is the single source of truth
- **Packaging** — `pyproject.toml` with correct entry point (`snack = "snacks.main:app"`), installs cleanly via `pipx` and `pip`
- **CI** — `ci.yml` runs `pytest` on push/PR to `main` across Python 3.10, 3.11, 3.12
- **Publish** — `publish.yml` triggers on `v*` tags: test → build → publish to PyPI (OIDC trusted publishing) → create GitHub Release with artifacts
- **Tests** — 33 tests across `test_commands.py` and `test_stash_commands.py`; config path monkeypatched, `add-remote` uses mocked tarball, no real network calls or writes to `~`
- **Documentation** — full README and 7-page wiki covering installation, configuration, all commands, snippet best practices, error reference, and contributing guide

## Test plan

- [x] Existing tests pass (`pytest tests/ -v`) — 33 passed
- [x] New tests added for all new behaviour (stash management, add-remote, version flag)
- [x] Tested manually with a real stash

## Notes for reviewer

`add-remote` uses only stdlib — no new runtime dependencies beyond Typer. The config file format changed from the original sectionless `stash=<path>` to INI-style `[stash.<name>]` sections, but the old format is still read transparently so existing installs won't break.

PyPI publish requires a one-time trusted publisher setup on pypi.org before the first tag push (repo Settings → Environments → `pypi`).